### PR TITLE
docs(ULT-59): improve testing documentation and workflow guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,17 @@ This file provides guidance to Claude Code when working with the UltraCoach proj
 ### At the start of EVERY new conversation
 
 1. **Read PLANNING.md** to understand project vision, architecture, and technical context
-2. **Check Linear workspace** at https://linear.app/ultracoach to see current milestone, pending tasks, and priorities
+2. **Check Linear workspace** using Linear MCP to see current milestone, pending tasks, and priorities
+   - Use `mcp__linear-server__list_issues` with team="Ultracoach" and state filters
+   - Read issue details with `mcp__linear-server__get_issue` for context
+   - Update issue status with `mcp__linear-server__update_issue` when completing work
 3. **Review this file** for project-specific guidance and context
 4. **Update task status in Linear** immediately when starting or completing work
+   - Move issues to "In Progress" when starting
+   - Move to "In Review" when creating PR
+   - Move to "Done" when PR is merged
 5. **Create new issues in Linear** when discovering additional tasks during development
+   - Use `mcp__linear-server__create_issue` with appropriate labels and project
 6. **Always use tslog library and utilities for logging (no console.log)**
 7. **Follow Next.js 15 Rendering Patterns** - Use Server/Client Component hybrid pattern for all authenticated routes (see `.context7-docs/nextjs/`)
 
@@ -26,6 +33,16 @@ This file provides guidance to Claude Code when working with the UltraCoach proj
 
 ### MCP Instructions
 
+### GitHub MCP Fallback
+
+When GitHub MCP is not available (authentication errors), use GitHub CLI (`gh`) as fallback:
+
+- `gh pr view` - View current PR
+- `gh pr create` - Create new PR
+- `gh pr list` - List PRs
+- `gh issue view` - View issue details
+- `gh issue create` - Create new issue
+
 ### Use Playwright MCP to investigate test failures and UI issues
 
 Playwright's MCP tooling is the fastest path to real root causes. Use it to inspect DOM, network, and console output when a test flakes. Prefer concrete data-testids over text selectors.
@@ -38,6 +55,7 @@ await page.getByText('Test Ultra Race').click()
 
 // After (stable: explicit test id)
 await page.getByTestId('race-name-0').click()
+```
 
 ### E2E authentication storageState filenames
 
@@ -45,11 +63,10 @@ await page.getByTestId('race-name-0').click()
 - Coach: use `./playwright/.auth/coach.json`
 
 Deprecated
+
 - `./playwright/.auth/user.json` was the legacy runner alias and is now deprecated. CI temporarily accepts it for a short deprecation window to keep older branches green, but all new/updated specs and Playwright projects should reference `runner.json`.
 
-```
-
-- When fetching data from Context7 MCP - add to the `.context7-docs` directory (gitignored). Create a new directory for the library if one does not exist. Before fetching from Context7 refer to `.context7-docs` to see if data and/or snippets have already been added
+````
 
 - When fetching data from Context7 MCP - add to the `.context7-docs` directory (gitignored). Create a new directory for the library if one does not exist. Before fetching from Context7 refer to `.context7-docs` to see if data and/or snippets have already been added
 
@@ -79,7 +96,7 @@ export default async function AuthenticatedPage() {
 export default function PageClient({ user }) {
   // Client-side state management and interactivity
 }
-```
+````
 
 ### Routes That MUST Be Dynamic
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ This file provides guidance to Claude Code when working with the UltraCoach proj
 
 ### MCP Instructions
 
-### GitHub MCP Fallback
+### GitHub MCP Fallback Commands
 
 When GitHub MCP is not available (authentication errors), use GitHub CLI (`gh`) as fallback:
 
@@ -66,8 +66,6 @@ Deprecated
 
 - `./playwright/.auth/user.json` was the legacy runner alias and is now deprecated. CI temporarily accepts it for a short deprecation window to keep older branches green, but all new/updated specs and Playwright projects should reference `runner.json`.
 
-````
-
 - When fetching data from Context7 MCP - add to the `.context7-docs` directory (gitignored). Create a new directory for the library if one does not exist. Before fetching from Context7 refer to `.context7-docs` to see if data and/or snippets have already been added
 
 ### Required Architecture Pattern
@@ -96,7 +94,7 @@ export default async function AuthenticatedPage() {
 export default function PageClient({ user }) {
   // Client-side state management and interactivity
 }
-````
+```
 
 ### Routes That MUST Be Dynamic
 

--- a/docs/testing/playwright-reliability.md
+++ b/docs/testing/playwright-reliability.md
@@ -1,0 +1,42 @@
+# Playwright Reliability Guide
+
+This guide documents the reliability standards applied across the E2E suite.
+
+## 1) Selector Strategy
+
+- Prefer `data-testid` with optional semantic attributes like `data-status`.
+- Keep role-based selectors where they are unique and stable.
+- Avoid broad text queries.
+- See `docs/testing/selector-best-practices.md`.
+
+## 2) Wait Strategy
+
+- Use `locator.waitFor({ state: 'visible' })` for readiness; use `clickWhenReady()` for interactions.
+- Avoid `networkidle` for apps with websockets/polling.
+- Use explicit loading-state checks (`waitUntilHidden()` for spinners, etc.).
+
+## 3) Authentication Reliability
+
+- Global auth setup uses direct API login and storageState per role.
+- Pre-flight health checks hit `/api/health` and `/api/health/database` with retries.
+- Target end-to-auth time: <5s in CI.
+
+## 4) Test Data Management
+
+- Prefer isolated, deterministic test data with unique identifiers.
+- Use idempotent setup and cleanup via API routes or seeds when available.
+- Avoid cross-test contamination by scoping mutations and using timestamps.
+
+## 5) Error Reporting
+
+- `trace: 'retain-on-failure'`, `screenshot: 'only-on-failure'`, `video: 'retain-on-failure'` in config.
+- Reporter generates HTML report locally and dot + HTML on CI.
+- Per-test annotations via `tests/utils/reporting.ts` add a `category` to failures.
+
+## Mapping to Success Criteria
+
+- Reliable selectors: added test ids and documentation.
+- <5s auth setup: direct API auth + health checks.
+- 90% flakiness reduction: robust waits, retry clicks, and deterministic data patterns.
+- Clear error reporting: traces/screenshots/videos on failure, HTML report.
+- Docs: this guide and selector best practices.

--- a/docs/testing/playwright-reliability.md
+++ b/docs/testing/playwright-reliability.md
@@ -7,7 +7,7 @@ This guide documents the reliability standards applied across the E2E suite.
 - Prefer `data-testid` with optional semantic attributes like `data-status`.
 - Keep role-based selectors where they are unique and stable.
 - Avoid broad text queries.
-- See `docs/testing/selector-best-practices.md`.
+- See [Selector Best Practices](./selector-best-practices.md).
 
 ## 2) Wait Strategy
 
@@ -31,7 +31,19 @@ This guide documents the reliability standards applied across the E2E suite.
 
 - `trace: 'retain-on-failure'`, `screenshot: 'only-on-failure'`, `video: 'retain-on-failure'` in config.
 - Reporter generates HTML report locally and dot + HTML on CI.
-- Per-test annotations via `tests/utils/reporting.ts` add a `category` to failures.
+- Use Playwright's built-in annotations to tag failures with a category:
+
+```ts
+import { expect, test } from '@playwright/test'
+
+test('saves a plan', async ({ page }) => {
+  test.info().annotations.push({ type: 'category', description: 'selectors' })
+  // …test body…
+  await expect(page.getByTestId('save-button')).toBeVisible()
+})
+```
+
+For structured logging, prefer `tests/utils/test-logger.ts` (tslog-backed).
 
 ## Mapping to Success Criteria
 

--- a/docs/testing/selector-best-practices.md
+++ b/docs/testing/selector-best-practices.md
@@ -1,0 +1,24 @@
+# Selector Best Practices (Playwright)
+
+Use stable, intention-revealing selectors to minimize flakiness.
+
+- Prefer data-testid attributes for app surfaces under test.
+  - Add `data-testid` at stable container boundaries, not on ephemeral children.
+  - Add semantic attributes too (e.g., `data-status`, `aria-*`) when useful for assertions.
+- Prefer role-based selectors when they are unique and stable: `getByRole('button', { name: 'Save' })`.
+- Avoid brittle text-only selectors and wide CSS queries with `:has-text()`.
+- For interactions, use `locator.waitFor({ state: 'visible' })` before `click()` or use `clickWhenReady(locator)` from `tests/utils/wait-helpers`.
+- Keep selectors co-located with components in code comments when adding new test ids.
+
+Examples
+
+```tsx
+// Good: explicit id and state
+<Card data-testid="training-plan-card" data-status={plan.archived ? 'archived' : 'active'}>
+
+// Good: role + name
+await page.getByRole('button', { name: /Begin Your Expedition/i }).click()
+
+// Better: helper wraps robust waits
+await clickWhenReady(page.getByRole('button', { name: /Save/ }))
+```


### PR DESCRIPTION
## Summary
- Add comprehensive Playwright test reliability documentation
- Document selector best practices for E2E testing  
- Update CLAUDE.md with Linear MCP integration instructions
- Add GitHub MCP fallback instructions for when MCP is unavailable
- Document authentication storage file naming conventions
- Clarify Server/Client component architecture patterns

## Documentation Added
- `docs/testing/playwright-reliability.md` - Guidelines for writing reliable Playwright tests
- `docs/testing/selector-best-practices.md` - Best practices for test selectors
- Updated `CLAUDE.md` - Session workflow improvements and MCP instructions

Part 6 of 6: Documentation Updates from PR #120 split

Relates to: ULT-59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a Playwright E2E reliability guide covering selectors, wait strategies, auth, test data, error reporting, and success criteria.
  - Added selector best-practices guidance recommending data-testid/role selectors and robust wait patterns.
  - Updated contributor guidance to use Linear MCP commands, explicit task status transitions, and creation labeling/process.
  - Added GitHub MCP fallback commands for PRs/issues and Playwright MCP tips for diagnosing test failures.
  - Clarified auth storageState naming, deprecated legacy aliases, and improved formatting/wording in guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->