### PR TITLE
Fix UI overlap on weekly planner page

### DIFF
--- a/src/app/weekly-planner/[runnerId]/page.tsx
+++ b/src/app/weekly-planner/[runnerId]/page.tsx
@@ -220,6 +220,9 @@ function RunnerWeeklyPage({
                   >
                     {selectedRunner.full_name || 'User'}
                   </p>
+                  {/* Status Chips - Note: connectedRunnersAtom only returns active relationships,
+                      so "Active" status is accurate. "Training" is a visual indicator that could be
+                      replaced with dynamic data from active training plans in a future enhancement. */}
                   <div className="flex items-center gap-2 mt-1">
                     <Chip
                       size="sm"


### PR DESCRIPTION
- Restructured header layout into clean two-row structure
- Fixed responsive breakpoints (mobile/tablet/desktop)
- Eliminated element overlaps with proper flex-shrink-0 classes
- Added text truncation for long runner names
- Improved week date formatting with whitespace-nowrap
- Enhanced accessibility with aria-labels on icon buttons
- Maintained Mountain Peak design system consistency

Resolves header overlap issue across all viewport sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized the weekly planner header into a two-row, fixed-alignment layout for improved consistency.
  * Moved week navigation (Prev / Today / Next) into a single horizontal group in the header.
  * Integrated runner details (avatar, name, Active/Training chips) into the header.
  * Added a conditional "Change Runner" action for coaches.
  * Improved responsive behavior and typography for various screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->