### PR TITLE
test: standardize remaining timeouts to CI_TIMEOUT constant

### DIFF
--- a/tests/e2e/workout-management.spec.ts
+++ b/tests/e2e/workout-management.spec.ts
@@ -140,7 +140,7 @@ test.describe('Workout Management', () => {
       await page.waitForSelector(
         '[data-testid="workout-card"], h3:has-text("No training sessions found")',
         {
-          timeout: 10000,
+          timeout: CI_TIMEOUT,
         }
       )
 
@@ -186,7 +186,7 @@ test.describe('Workout Management', () => {
       await page.waitForSelector(
         '[data-testid="workout-card"], h3:has-text("No training sessions found")',
         {
-          timeout: 10000,
+          timeout: CI_TIMEOUT,
         }
       )
 
@@ -302,7 +302,7 @@ test.describe('Workout Management', () => {
           await expect(stravaButton).toHaveText(/syncing/i)
 
           // Should eventually show success
-          await expect(page.getByText(/synced with strava/i)).toBeVisible({ timeout: 10000 })
+          await expect(page.getByText(/synced with strava/i)).toBeVisible({ timeout: CI_TIMEOUT })
 
           // stravaActivitiesAtom should be updated
           await expect(completedWorkout.locator('[data-testid="strava-badge"]')).toBeVisible()


### PR DESCRIPTION
- Replace hardcoded 10000ms timeouts with CI_TIMEOUT (15000ms) in workout-management.spec.ts
- Affects 3 instances: 2x waitForSelector and 1x toBeVisible
- Addresses CodeRabbit review comments #1, #2, #3, #7 for consistent CI reliability
- Ensures all test timeouts are maintainable through single constant