### PR TITLE
fix(calendar): resolve NaN values in weekly volume calculations

### DIFF
--- a/src/app/calendar/CalendarPageClient.tsx
+++ b/src/app/calendar/CalendarPageClient.tsx
@@ -17,6 +17,7 @@ import {
   calendarUiStateAtom,
   connectedRunnersAtom,
   filteredWorkoutsAtom,
+  weeklyWorkoutStatsAtom,
   workoutStatsAtom,
 } from '@/lib/atoms/index'
 import { asyncTrainingPlansAtom } from '@/lib/atoms/training-plans'
@@ -78,6 +79,7 @@ function CalendarContent({ user }: Props) {
   const { loading: workoutsLoading, fetchWorkouts } = useWorkouts()
   const filteredWorkouts = useAtomValue(filteredWorkoutsAtom)
   const workoutStats = useAtomValue(workoutStatsAtom)
+  const weeklyStats = useAtomValue(weeklyWorkoutStatsAtom)
   const [calendarUiState, setCalendarUiState] = useAtom(calendarUiStateAtom)
   const trainingPlans = useAtomValue(asyncTrainingPlansAtom) // Using async atom with Suspense
   const connectedRunners = useAtomValue(connectedRunnersAtom) // Suspense-friendly async atom
@@ -338,19 +340,19 @@ function CalendarContent({ user }: Props) {
                   <div className="flex justify-between text-sm">
                     <span className="text-foreground-600">Planned Distance:</span>
                     <span className="font-medium">
-                      {Number(workoutStats.plannedDistance || 0).toFixed(1)} mi
+                      {Number(weeklyStats.plannedDistance || 0).toFixed(1)} mi
                     </span>
                   </div>
                   <div className="flex justify-between text-sm">
                     <span className="text-foreground-600">Completed Distance:</span>
                     <span className="font-medium text-success">
-                      {Number(workoutStats.completedDistance || 0).toFixed(1)} mi
+                      {Number(weeklyStats.completedDistance || 0).toFixed(1)} mi
                     </span>
                   </div>
                   <div className="flex justify-between text-sm">
                     <span className="text-foreground-600">Avg Intensity:</span>
                     <span className="font-medium">
-                      {Number(workoutStats.avgIntensity || 0).toFixed(1)}
+                      {Number(weeklyStats.avgIntensity || 0).toFixed(1)}
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
- Add toNumber helper to safely convert values and handle NaN cases
- Create weeklyWorkoutStatsAtom for accurate weekly statistics
- Update CalendarPageClient to use weekly stats instead of all filtered workouts
- Ensure all distance and intensity calculations return valid numbers

Fixes issue where NaN values appeared in Weekly Volume section when workout data contained invalid numeric values or when performing calculations on empty datasets.