### PR TITLE
fix(feedback): correct Resend verified domain from .app to .dev

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -164,7 +164,7 @@ export async function POST(request: NextRequest) {
           const emailText = generateFeedbackEmailText(emailProps)
 
           await resend.emails.send({
-            from: 'UltraCoach Feedback <feedback@ultracoach.app>',
+            from: 'UltraCoach Feedback <feedback@ultracoach.dev>',
             to: feedbackEmail,
             replyTo: feedback.user_email || undefined,
             subject: `[UltraCoach Feedback] ${feedbackTypeLabel} - ${sanitizedTitle}`,


### PR DESCRIPTION
Updated the "from" email address to use ultracoach.dev instead of ultracoach.app to match the verified Resend domain.

This fixes the email delivery issue where feedback emails were not being sent because Resend requires the "from" address to use a verified domain.

Changed:
- from: 'UltraCoach Feedback <feedback@ultracoach.app>'
+ from: 'UltraCoach Feedback <feedback@ultracoach.dev>'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sender email address for feedback notifications to use the correct domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->