### PR TITLE
fix(tests): remove redundant test.use() storageState calls causing CI…

### DIFF
--- a/tests/e2e/session-persistence.spec.ts
+++ b/tests/e2e/session-persistence.spec.ts
@@ -23,8 +23,6 @@ import {
 
 test.describe('Session Persistence', () => {
   test.describe('Page Refresh Scenarios', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test('should maintain session on dashboard refresh', async ({ page }) => {
       // Navigate to dashboard
       await navigateToDashboard(page, 'runner')
@@ -93,8 +91,6 @@ test.describe('Session Persistence', () => {
   })
 
   test.describe('Cross-Route Navigation', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test('should maintain session across all protected routes', async ({ page }, testInfo) => {
       // Increase timeout for comprehensive 6-route navigation test
       // (Next.js compilation can take 20-30s for some routes on first visit)
@@ -191,8 +187,6 @@ test.describe('Session Persistence', () => {
   })
 
   test.describe('Browser Navigation', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test('should maintain session with browser back/forward', async ({ page }) => {
       // Start on dashboard
       await navigateToDashboard(page, 'runner')
@@ -226,8 +220,6 @@ test.describe('Session Persistence', () => {
   })
 
   test.describe('Session Validation', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test('should redirect unauthenticated users to signin', async ({ page }) => {
       // Clear all cookies and storage
       await page.context().clearCookies()
@@ -287,8 +279,6 @@ test.describe('Session Persistence', () => {
   })
 
   test.describe('Authentication Flow Integration', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test.skip('should establish session after successful signin', async ({ page }) => {
       // SKIPPED: This test is redundant with auth.setup.ts (validates API signin)
       // and auth-flows.spec.ts (validates form signin flow).
@@ -373,8 +363,6 @@ test.describe('Session Persistence', () => {
   })
 
   test.describe('Long-Running Session', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test.skip('should maintain session across multiple operations', async ({ page }) => {
       // SKIPPED: Redundant with other session persistence tests and auth.setup.ts.
       // This test also uses UI form submission which is failing intermittently.

--- a/tests/e2e/single-route-test.spec.ts
+++ b/tests/e2e/single-route-test.spec.ts
@@ -2,8 +2,6 @@ import { expect, test } from '@playwright/test'
 
 import { TEST_TIMEOUTS } from '../utils/test-helpers'
 
-test.use({ storageState: './playwright/.auth/runner.json' })
-
 // Parameterized route tests - reduces duplication and improves maintainability
 const routesToTest = [
   { route: '/dashboard/runner', name: 'runner-home' },

--- a/tests/e2e/workout-atoms.spec.ts
+++ b/tests/e2e/workout-atoms.spec.ts
@@ -15,8 +15,6 @@ import { TEST_TIMEOUTS } from '../utils/test-helpers'
 
 test.describe('Workout Atoms Functionality', () => {
   test.describe('Runner Dashboard Workout Display', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test('should display upcoming workouts on runner dashboard', async ({ page }) => {
       // Navigate to runner dashboard
       await page.goto('/dashboard/runner')
@@ -84,8 +82,6 @@ test.describe('Workout Atoms Functionality', () => {
   })
 
   test.describe('Weekly Planner Workout Persistence', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test('should persist workouts on weekly planner after navigation', async ({ page }) => {
       // First, go to calendar/weekly planner
       await page.goto('/calendar')
@@ -149,8 +145,6 @@ test.describe('Workout Atoms Functionality', () => {
   })
 
   test.describe('Workout Completion Modal', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test('should successfully submit workout completion modal', async ({ page }) => {
       // Navigate to workouts page
       await page.goto('/workouts')
@@ -291,8 +285,6 @@ test.describe('Workout Atoms Functionality', () => {
   })
 
   test.describe('Workout Atom State Synchronization', () => {
-    test.use({ storageState: './playwright/.auth/runner.json' })
-
     test('should refresh workouts when navigating between pages', async ({ page }) => {
       // Start on workouts page
       await page.goto('/workouts')


### PR DESCRIPTION
… failures

- Remove test-level storageState configuration that conflicts with project-level config
- Tests in chromium-other project already inherit runner.json storageState
- Nested test.use() calls were causing authentication to fail in CI
- Simplified test configuration by relying on project-level auth setup

Fixes:
- workout-atoms.spec.ts: removed 4 redundant test.use() calls
- single-route-test.spec.ts: removed redundant test.use() call
- session-persistence.spec.ts: removed 6 redundant test.use() calls

Result: Tests now properly inherit authentication from project configuration