### PR TITLE
Fix workout posting failures

### DIFF
--- a/src/lib/__tests__/workout-completion-atoms.test.ts
+++ b/src/lib/__tests__/workout-completion-atoms.test.ts
@@ -111,7 +111,7 @@ describe('Workout Completion Atoms', () => {
       })
 
       expect(fetch).toHaveBeenCalledWith('/api/workouts/workout-456/log', {
-        method: 'POST',
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'same-origin',
         body: JSON.stringify(workoutData),
@@ -142,7 +142,7 @@ describe('Workout Completion Atoms', () => {
       })
 
       expect(fetch).toHaveBeenCalledWith('/api/workouts/workout-789/log', {
-        method: 'POST',
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'same-origin',
         body: JSON.stringify(comprehensiveData),
@@ -324,7 +324,7 @@ describe('Workout Completion Atoms', () => {
         })
 
         expect(fetch).toHaveBeenCalledWith('/api/workouts/workout-123/log', {
-          method: 'POST',
+          method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'same-origin',
           body: JSON.stringify(workoutData),

--- a/src/lib/atoms/__tests__/workouts.test.ts
+++ b/src/lib/atoms/__tests__/workouts.test.ts
@@ -429,7 +429,7 @@ describe('Workouts Atoms', () => {
         })
 
         expect(fetch).toHaveBeenCalledWith('/api/workouts/w1/log', {
-          method: 'POST',
+          method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'same-origin',
           body: JSON.stringify(workoutData),

--- a/src/lib/atoms/workouts.ts
+++ b/src/lib/atoms/workouts.ts
@@ -436,7 +436,7 @@ export const logWorkoutDetailsAtom = atom(
       }
 
       const response = await fetch(`/api/workouts/${workoutId}/log`, {
-        method: 'POST',
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'same-origin',
         body: JSON.stringify(data),


### PR DESCRIPTION
Fixed 405 Method Not Allowed error when logging workout details. The API endpoint /api/workouts/[id]/log only accepts PUT and GET methods, but the client was using POST.

Changes:
- Updated logWorkoutDetailsAtom to use PUT instead of POST
- Updated all test files to expect PUT method
- Resolves PostHog error: https://us.posthog.com/project/251417/events/019aad6a-72f6-7b90-a941-6ec33418481c

Files updated:
- src/lib/atoms/workouts.ts (line 439)
- src/lib/atoms/__tests__/workouts.test.ts (line 432)
- src/lib/__tests__/workout-completion-atoms.test.ts (lines 114, 145, 327)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized the workout logging mechanism to enhance system reliability and ensure consistent backend interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->