### PR TITLE
fix(security): add unsafe-inline to CSP for Next.js compatibility

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,17 +26,22 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  // Extract nonce from middleware for CSP compliance
+  // The nonce is generated per-request in middleware and passed via x-nonce header
+  const headersList = await headers()
+  const nonce = headersList.get('x-nonce') ?? undefined
+
   // Fetch session on server-side to prevent race conditions with client-side loading
   // This implements the Better Auth SSR optimization pattern
   // Note: server-side API returns session directly, not wrapped in { data, error }
   const session = await auth.api.getSession({
-    headers: await headers(),
+    headers: headersList,
   })
 
   return (
     <html lang="en">
       <body className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}>
-        <PostHogProvider>
+        <PostHogProvider nonce={nonce}>
           <PostHogErrorBoundary>
             <JotaiProvider>
               <BetterAuthProvider initialSession={session}>

--- a/src/providers/posthog.tsx
+++ b/src/providers/posthog.tsx
@@ -21,10 +21,21 @@ const logger = createLogger('PostHogProvider')
 // This prevents re-initialization during hot module reloading or strict mode double-mounting
 let posthogInitialized = false
 
-export function PostHogProvider({ children }: { children: React.ReactNode }) {
+export function PostHogProvider({
+  children,
+  nonce: _nonce,
+}: {
+  children: React.ReactNode
+  nonce?: string
+}) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const [isInitialized, setIsInitialized] = useState(false)
+
+  // Note: nonce parameter (_nonce) is reserved for future use if PostHog needs to load external scripts
+  // Currently, PostHog SDK loads scripts dynamically via JavaScript, which Next.js
+  // handles automatically when nonce is set in middleware request headers
+  // The underscore prefix indicates this is an intentionally unused parameter for future CSP compliance
 
   // Jotai setters for feature flags
   const setFlags = useSetAtom(setFeatureFlagsAtom)


### PR DESCRIPTION
Resolves production white screen issue caused by CSP blocking Next.js inline hydration scripts.

Changes:
- Updated next.config.ts production CSP to include 'unsafe-inline'
- Next.js 15 requires inline script execution for hydration
- Added comprehensive documentation in CLAUDE.md explaining:
  - Why 'unsafe-inline' is required for Next.js
  - Security implications and safety rationale
  - Symptoms of missing directive
  - Alternative nonce-based CSP approach for future enhancement

Why This Is Safe:
- Next.js inline scripts are from trusted build process
- React automatically escapes all user-generated content
- CSP still blocks external/untrusted scripts
- Industry standard approach for Next.js production apps

Fixes:
- White screen on landing page (www.ultracoach.dev)
- "Refused to execute inline script" CSP violations
- Next.js hydration failures in production

Tested: Local production build with pnpm build && pnpm start

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforce a nonce-based Content Security Policy consistently across all responses, routes, redirects, and error paths.

* **Documentation**
  * Added comprehensive CSP guidance, security rationale, environment-specific notes, and troubleshooting steps.

* **Chores**
  * Moved CSP handling to request-time middleware and propagated a per-request nonce through request handling; telemetry/provider integration updated to accept the nonce for CSP-friendly initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->