### PR TITLE
fix(invitations): address PR #226 review comments

### DIFF
--- a/src/app/api/invitations/[id]/resend/route.ts
+++ b/src/app/api/invitations/[id]/resend/route.ts
@@ -29,8 +29,6 @@ interface RouteParams {
   params: Promise<{ id: string }>
 }
 
-const MAX_RESENDS = 3
-
 /**
  * POST /api/invitations/[id]/resend - Resend an invitation email
  */
@@ -94,12 +92,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     // Check resend limit
-    if (invitation.resend_count >= MAX_RESENDS) {
+    if (invitation.resend_count >= INVITATION_CONFIG.MAX_RESENDS) {
       return NextResponse.json(
         {
           success: false,
           error: 'RESEND_LIMIT',
-          message: `Maximum resend limit (${MAX_RESENDS}) reached`,
+          message: `Maximum resend limit (${INVITATION_CONFIG.MAX_RESENDS}) reached`,
         },
         { status: 429 }
       )

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -188,6 +188,7 @@ export async function POST(request: NextRequest) {
       // Still return success - invitation was created, email can be resent
     }
 
+    // Return consistent response shape matching GET endpoint format
     return NextResponse.json(
       {
         success: true,
@@ -195,9 +196,22 @@ export async function POST(request: NextRequest) {
           id: newInvitation.id,
           inviteeEmail: newInvitation.invitee_email,
           invitedRole: newInvitation.invited_role,
+          personalMessage: newInvitation.personal_message,
           status: newInvitation.status,
-          expiresAt: newInvitation.expires_at,
           createdAt: newInvitation.created_at,
+          expiresAt: newInvitation.expires_at,
+          acceptedAt: null,
+          declinedAt: null,
+          resendCount: newInvitation.resend_count,
+          lastResentAt: newInvitation.last_resent_at,
+          isSent: true,
+          isReceived: false,
+          inviter: {
+            id: sessionUser.id,
+            name: sessionUser.name,
+            email: sessionUser.email,
+          },
+          isExpired: false,
         },
         emailSent: emailResult.success,
       },

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -14,6 +14,7 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useAtom } from 'jotai'
 import { Flag, Lock, Mail, MountainSnow, User, UserPlus } from 'lucide-react'
+import { toast } from 'sonner'
 
 import React, { useEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
@@ -138,16 +139,26 @@ export default function SignUp() {
 
             if (acceptData.success) {
               logger.info('Invitation accepted successfully')
+              toast.success('Welcome! You have been connected successfully.')
               // Redirect to appropriate dashboard
               router.push(acceptData.redirectUrl || '/dashboard')
               return
             } else {
               logger.warn('Failed to accept invitation after signup:', acceptData.message)
-              // Continue with normal flow if invitation acceptance fails
+              // Surface error to user but allow them to continue
+              toast.warning(
+                acceptData.message ||
+                  'Could not auto-accept invitation. You can accept it from your dashboard.',
+                { duration: 5000 }
+              )
             }
           } catch (acceptError) {
             logger.error('Error accepting invitation after signup:', acceptError)
-            // Continue with normal flow
+            // Surface error to user but allow them to continue
+            toast.warning(
+              'Could not auto-accept invitation. You can accept it from your dashboard.',
+              { duration: 5000 }
+            )
           }
         }
 

--- a/src/app/relationships/RelationshipsPageContent.tsx
+++ b/src/app/relationships/RelationshipsPageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Card, CardBody } from '@heroui/react'
-import { useAtom } from 'jotai'
+import { useSetAtom } from 'jotai'
 
 import { useCallback } from 'react'
 
@@ -12,24 +12,36 @@ import { RelationshipsList } from '@/components/relationships/RelationshipsList'
 import { RunnerSelector } from '@/components/relationships/RunnerSelector'
 import { relationshipsAtom } from '@/lib/atoms/index'
 import type { User } from '@/lib/better-auth-client'
+import { createLogger } from '@/lib/logger'
+
+const logger = createLogger('RelationshipsPageContent')
 
 interface RelationshipsPageContentProps {
   user: User
 }
 
+/**
+ * Main content component for the relationships page.
+ * Displays coach-runner relationships and connection management UI.
+ */
 export function RelationshipsPageContent({ user }: RelationshipsPageContentProps) {
-  const [, setRelationships] = useAtom(relationshipsAtom)
+  const setRelationships = useSetAtom(relationshipsAtom)
 
+  /**
+   * Refreshes the relationships atom with fresh data from the API.
+   * Called after relationship updates to keep the UI in sync.
+   */
   const handleRelationshipChange = useCallback(async () => {
-    // Refresh relationships atom to get updated data
     try {
-      const response = await fetch('/api/coach-runners')
+      const response = await fetch('/api/coach-runners', {
+        credentials: 'same-origin',
+      })
       if (response.ok) {
         const data = await response.json()
         setRelationships(data.relationships || [])
       }
     } catch (error) {
-      console.error('Failed to refresh relationships:', error)
+      logger.error('Failed to refresh relationships:', error)
     }
   }, [setRelationships])
 

--- a/src/components/relationships/AsyncInvitationsList.tsx
+++ b/src/components/relationships/AsyncInvitationsList.tsx
@@ -19,7 +19,7 @@ import {
   DropdownTrigger,
   Tooltip,
 } from '@heroui/react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { toast } from 'sonner'
 
 import { useCallback, useMemo } from 'react'
@@ -33,6 +33,7 @@ import {
   revokingInvitationIdsAtom,
   sentInvitationsAsyncAtom,
 } from '@/lib/atoms/invitations'
+import { INVITATION_CONFIG } from '@/lib/invitation-tokens'
 import { createLogger } from '@/lib/logger'
 
 const logger = createLogger('AsyncInvitationsList')
@@ -64,8 +65,8 @@ const statusLabels: Record<Invitation['status'], string> = {
 export function AsyncInvitationsList({ onInvitationUpdated }: AsyncInvitationsListProps) {
   const invitations = useAtomValue(sentInvitationsAsyncAtom)
   const setIsModalOpen = useSetAtom(isInviteModalOpenAtom)
-  const [resendingIds] = useAtom(resendingInvitationIdsAtom)
-  const [revokingIds] = useAtom(revokingInvitationIdsAtom)
+  const resendingIds = useAtomValue(resendingInvitationIdsAtom)
+  const revokingIds = useAtomValue(revokingInvitationIdsAtom)
   const resendInvitation = useSetAtom(resendInvitationAtom)
   const revokeInvitation = useSetAtom(revokeInvitationAtom)
 
@@ -162,7 +163,8 @@ export function AsyncInvitationsList({ onInvitationUpdated }: AsyncInvitationsLi
                 const isResending = resendingIds.has(invitation.id)
                 const isRevoking = revokingIds.has(invitation.id)
                 const isPending = invitation.status === 'pending'
-                const canResend = isPending && invitation.resendCount < 3
+                const canResend =
+                  isPending && invitation.resendCount < INVITATION_CONFIG.MAX_RESENDS
 
                 return (
                   <div
@@ -222,12 +224,14 @@ export function AsyncInvitationsList({ onInvitationUpdated }: AsyncInvitationsLi
                               size="sm"
                               variant="light"
                               disabled={isResending || isRevoking}
+                              aria-label="Invitation actions menu"
                             >
                               <svg
                                 className="h-4 w-4"
                                 fill="none"
                                 stroke="currentColor"
                                 viewBox="0 0 24 24"
+                                aria-hidden="true"
                               >
                                 <path
                                   strokeLinecap="round"
@@ -273,8 +277,13 @@ export function AsyncInvitationsList({ onInvitationUpdated }: AsyncInvitationsLi
 
                       {invitation.status === 'accepted' && (
                         <Tooltip content="This user has joined">
-                          <span className="text-success">
-                            <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+                          <span className="text-success" role="img" aria-label="Accepted">
+                            <svg
+                              className="h-5 w-5"
+                              fill="currentColor"
+                              viewBox="0 0 20 20"
+                              aria-hidden="true"
+                            >
                               <path
                                 fillRule="evenodd"
                                 d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"

--- a/src/lib/invitation-tokens.ts
+++ b/src/lib/invitation-tokens.ts
@@ -3,6 +3,10 @@ import { createHash, randomBytes, timingSafeEqual } from 'crypto'
 const TOKEN_LENGTH = 32 // 256 bits of entropy
 const DEFAULT_EXPIRATION_DAYS = 14
 const MAX_EXPIRATION_DAYS = 30
+/** Maximum number of times an invitation can be resent */
+const MAX_RESENDS = 3
+/** Default fallback URL for development */
+const DEFAULT_BASE_URL = 'http://localhost:3001'
 
 export interface TokenData {
   /** URL-safe token for email link */
@@ -74,26 +78,39 @@ export function isTokenExpired(expiresAt: Date): boolean {
 }
 
 /**
+ * Gets the application base URL from environment or falls back to localhost
+ * @returns The base URL for building invitation links
+ */
+export function getBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL || DEFAULT_BASE_URL
+}
+
+/**
  * Builds the full invitation acceptance URL
+ * @param token - The invitation token to include in the URL
+ * @returns The complete acceptance URL
  */
 export function buildInvitationUrl(token: string): string {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001'
-  return `${baseUrl}/invitations/accept/${token}`
+  return `${getBaseUrl()}/invitations/accept/${token}`
 }
 
 /**
  * Builds the invitation decline URL
+ * @param token - The invitation token to include in the URL
+ * @returns The complete decline URL
  */
 export function buildDeclineUrl(token: string): string {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001'
-  return `${baseUrl}/invitations/decline/${token}`
+  return `${getBaseUrl()}/invitations/decline/${token}`
 }
 
 /**
- * Configuration constants exposed for use elsewhere
+ * Configuration constants exposed for use elsewhere.
+ * Use these constants to ensure consistency between client and server.
  */
 export const INVITATION_CONFIG = {
   DEFAULT_EXPIRATION_DAYS,
   MAX_EXPIRATION_DAYS,
   TOKEN_LENGTH,
+  MAX_RESENDS,
+  DEFAULT_BASE_URL,
 } as const


### PR DESCRIPTION
This commit addresses all code review comments from PR #226:

1. Centralize MAX_RESENDS constant in INVITATION_CONFIG
   - Removed hardcoded magic number (3) from resend route and UI
   - Added to invitation-tokens.ts exported constants

2. Fix HTTP semantics in accept route GET handler
   - Removed mutation (expiration update) from GET endpoint
   - Deferred status update to POST handler per REST conventions

3. Centralize hardcoded localhost:3001 environment values
   - Created getBaseUrl() helper in invitation-tokens.ts
   - Added DEFAULT_BASE_URL constant

4. Fix inconsistent POST response in invitations API
   - POST now returns same shape as GET (with all fields)
   - Added isSent, isReceived, inviter object, isExpired

5. Fix non-null assertions for expires_at
   - Added proper null checks before calling isTokenExpired

6. Use Zod email validation in InviteRunnerModal
   - Matches server-side validation using z.string().email()

7. Fix error handling in invitations atoms
   - Errors now re-throw instead of silent empty array return
   - Let Suspense error boundaries handle failures

8. Fix Jotai hook usage
   - Changed useAtom to useSetAtom/useAtomValue where appropriate
   - RelationshipsPageContent, InviteRunnerModal, AsyncInvitationsList

9. Add credentials: 'same-origin' to RelationshipsPageContent fetch

10. Fix redirect URL to consider invited_role in accept route
    - Now uses invitation.invited_role instead of sessionUser.userType

11. Surface invitation auto-accept errors to user in signup
    - Added toast notifications for success and failure cases

12. Replace console.error with tslog in RelationshipsPageContent

13. Fix accessibility in AsyncInvitationsList
    - Added aria-label to SVG buttons
    - Added aria-hidden to decorative SVGs
    - Added role="img" to icon containers

14. Add comprehensive JSDoc docstrings
    - All atoms, functions, and key components documented