### PR TITLE
fix(invitations): use Vercel env vars for production URL

### DIFF
--- a/src/lib/invitation-tokens.ts
+++ b/src/lib/invitation-tokens.ts
@@ -80,11 +80,64 @@ export function isTokenExpired(expiresAt: Date | string): boolean {
 }
 
 /**
- * Gets the application base URL from environment or falls back to localhost
+ * Normalizes a URL or hostname by trimming whitespace and removing trailing slashes
+ * @param value - The URL or hostname to normalize
+ * @returns Normalized string or null if empty/whitespace-only
+ */
+function normalizeUrl(value: string | undefined): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  // Strip trailing slashes to prevent double-slash URLs
+  return trimmed.replace(/\/+$/, '')
+}
+
+/**
+ * Strips http:// or https:// protocol from a hostname
+ * Handles misconfigured env vars that accidentally include protocol
+ */
+function stripProtocol(hostname: string): string {
+  return hostname.replace(/^https?:\/\//, '')
+}
+
+/**
+ * Gets the application base URL from environment variables
+ *
+ * Priority order:
+ * 1. NEXT_PUBLIC_APP_URL - Explicitly set app URL (recommended for production)
+ * 2. VERCEL_PROJECT_PRODUCTION_URL - Auto-set by Vercel for production domain
+ * 3. VERCEL_URL - Auto-set by Vercel for preview/production deployments
+ * 4. DEFAULT_BASE_URL - Fallback for local development
+ *
  * @returns The base URL for building invitation links
+ * @throws Error if NEXT_PUBLIC_APP_URL is set but missing http:// or https:// protocol
  */
 export function getBaseUrl(): string {
-  return process.env.NEXT_PUBLIC_APP_URL || DEFAULT_BASE_URL
+  // Priority 1: Explicitly configured app URL
+  const appUrl = normalizeUrl(process.env.NEXT_PUBLIC_APP_URL)
+  if (appUrl) {
+    if (!appUrl.startsWith('http://') && !appUrl.startsWith('https://')) {
+      throw new Error(`NEXT_PUBLIC_APP_URL must start with http:// or https://, got: ${appUrl}`)
+    }
+    return appUrl
+  }
+
+  // Priority 2: Vercel production URL (hostname only, needs https://)
+  // Strip any accidental protocol to prevent double-protocol URLs
+  const prodUrl = normalizeUrl(process.env.VERCEL_PROJECT_PRODUCTION_URL)
+  if (prodUrl) {
+    return `https://${stripProtocol(prodUrl)}`
+  }
+
+  // Priority 3: Vercel deployment URL (hostname only, needs https://)
+  // Strip any accidental protocol to prevent double-protocol URLs
+  const vercelUrl = normalizeUrl(process.env.VERCEL_URL)
+  if (vercelUrl) {
+    return `https://${stripProtocol(vercelUrl)}`
+  }
+
+  // Priority 4: Local development fallback
+  return DEFAULT_BASE_URL
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes invitation email URLs pointing to `localhost:3001` instead of production domain.

### Problem
When sending invitation emails in production, the acceptance URL was generated as:
```
http://localhost:3001/invitations/accept/{token}
```

instead of:
```
https://www.ultracoach.dev/invitations/accept/{token}
```

### Root Cause
The `getBaseUrl()` function in `src/lib/invitation-tokens.ts` only checked `NEXT_PUBLIC_APP_URL` before falling back to `localhost:3001`. Since this env var wasn't set in Vercel, it used the dev fallback.

### Solution
Updated `getBaseUrl()` to use Vercel's automatic environment variables as fallbacks:

1. `NEXT_PUBLIC_APP_URL` - Explicitly configured (recommended)
2. `VERCEL_PROJECT_PRODUCTION_URL` - Auto-set by Vercel for production domain
3. `VERCEL_URL` - Auto-set by Vercel for preview/production deployments  
4. `localhost:3001` - Local development fallback

## Testing
- Verified invitation flow works in production via Browserbase E2E test
- Email delivery confirmed working (after RESEND_FROM_EMAIL fix)
- This fix will ensure URLs point to correct production domain

## Deployment
Merge and deploy - invitation emails will immediately use correct URLs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved base URL detection with a clear priority order across environments for more predictable behavior.
  * Added URL normalization to trim whitespace, strip protocols when appropriate, and remove trailing slashes for consistent handling.
* **Bug Fixes**
  * Stricter validation and null handling for configured base URLs to reduce failures from misconfiguration and make errors clearer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->