### PR TITLE
fix(dates): use date-fns for CSV date parsing in race bulk import

### DIFF
--- a/src/app/api/races/bulk-import/route.ts
+++ b/src/app/api/races/bulk-import/route.ts
@@ -10,6 +10,7 @@ import {
   raceBulkImportLimiter,
 } from '@/lib/redis-rate-limiter'
 import { races } from '@/lib/schema'
+import { parseCSVDate } from '@/lib/utils/date'
 import { getServerSession } from '@/utils/auth-server'
 
 const logger = createLogger('RaceBulkImportAPI')
@@ -148,7 +149,7 @@ export async function POST(request: NextRequest) {
         // Set defaults for missing fields
         const raceData = {
           name: importRace.name,
-          date: importRace.date ? new Date(importRace.date) : null,
+          date: parseCSVDate(importRace.date),
           distance_miles: String(importRace.distance_miles || 0),
           distance_type: importRace.distance_type || 'Custom',
           location: importRace.location || 'Unknown Location',


### PR DESCRIPTION
## Summary

Resolves [ULT-100](https://linear.app/ultracoach/issue/ULT-100) - Convert date logic in Race Import Modal to date-fns handlers.

### Problem

The CSV date parsing in race bulk import used `new Date(importRace.date)` which is:
- **Engine-dependent**: Different behavior across browsers and Node.js versions
- **Timezone-sensitive**: UTC drift on date-only strings like `"2024-01-15"`
- **Inconsistent**: Doesn't align with project's established date handling patterns

### Solution

Added `parseCSVDate()` helper function to `src/lib/utils/date.ts` that:
- Uses date-fns with explicit format patterns for deterministic behavior
- Supports multiple CSV date formats (ISO, US, EU, month names)
- Prevents timezone drift on date-only strings
- Aligns with existing `parseInput()` and `toLocalYMD()` patterns

### Supported Date Formats

| Format | Example |
|--------|---------|
| ISO date-only | `2024-01-15` |
| US format | `01/15/2024` |
| EU format | `15/01/2024` |
| Long month | `January 15, 2024` |
| Long month with ordinal | `January 15th, 2024` |
| Short month | `Jan 15, 2024` |
| Day-first | `15 Jan 2024` |
| US with dashes | `01-15-2024` |

### Changes

- **src/lib/utils/date.ts**: Added `parseCSVDate()` helper with multi-format support
- **src/app/api/races/bulk-import/route.ts**: Replaced `new Date()` with `parseCSVDate()`

### Testing

- Lint: ✅ No errors or warnings
- TypeScript: ✅ Compiles cleanly
- Build: ✅ Production build succeeds

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)