### PR TITLE
Add race import capabilities for runners

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -150,10 +150,11 @@ export default defineConfig({
       // No dependencies - unauth flows should start fresh without pre-auth state
     },
 
-    // Authenticated coach tests for race import
+    // Authenticated coach tests for race import (excludes @runner tagged tests)
     {
       name: 'chromium-race-import-coach',
       testMatch: /race-import\.spec\.ts/,
+      grepInvert: /@runner/,
       use: {
         ...devices['Desktop Chrome'],
         // Use saved coach authentication state
@@ -162,11 +163,11 @@ export default defineConfig({
       dependencies: ['setup-coach'], // Ensure coach auth setup completes first
     },
 
-    // Runner tests for race import (verify no access)
+    // Runner tests for race import (verify runners CAN import - ULT-18)
     {
       name: 'chromium-race-import-runner',
       testMatch: /race-import\.spec\.ts/,
-      grep: /should not allow runners to import/,
+      grep: /@runner/,
       use: {
         ...devices['Desktop Chrome'],
         // Use saved runner authentication state


### PR DESCRIPTION
…(ULT-18)

- Add runner-specific E2E tests for race import (GPX, CSV, duplicate detection)
- Implement @runner tag-based filtering to separate coach/runner test suites
- Update Playwright config with grepInvert for coach tests, grep for runner tests
- Remove obsolete negative test (runners should NOT import) per ULT-18 requirement
- Fix combined modal locators per CodeRabbit feedback (use getByRole('dialog'))
- All new runner tests use API mocking for CI determinism

Acceptance criteria addressed:
- ✅ Runners should be able to import GPX files
- ✅ Runners should be able to import CSV files
- ✅ Duplicate detection informs the user
- ✅ Tests updated and passing (lint, typecheck)

Closes ULT-18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Expanded test coverage for race import functionality with improved modal detection and enhanced workflows for import scenarios including file uploads and duplicate detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->