### PR TITLE
fix(dashboard): use athletesPerPage from atom instead of hardcoded value

### DIFF
--- a/src/components/dashboard/coach/AthletesGrid.tsx
+++ b/src/components/dashboard/coach/AthletesGrid.tsx
@@ -23,6 +23,7 @@ import {
   athleteStatusCountsAtom,
   athleteStatusFilterAtom,
   athleteViewModeAtom,
+  coachDashboardStateAtom,
   paginatedAthletesAtom,
 } from '@/lib/atoms/dashboard'
 
@@ -39,8 +40,9 @@ function AthletesGridComponent() {
   const [currentPage, setCurrentPage] = useAtom(athleteCurrentPageAtom)
   const statusCounts = useAtomValue(athleteStatusCountsAtom)
   const paginatedData = useAtomValue(paginatedAthletesAtom)
+  const { athletesPerPage } = useAtomValue(coachDashboardStateAtom)
 
-  // Debounced search handler
+  // Search handler - updates search term immediately (atom handles page reset)
   const handleSearchChange = useCallback(
     (value: string) => {
       // Simple immediate update - the atom handles page reset
@@ -231,8 +233,8 @@ function AthletesGridComponent() {
             {paginatedData.totalPages > 1 && (
               <div className="flex items-center justify-between mt-6 pt-4 border-t border-divider">
                 <p className="text-sm text-foreground-500">
-                  Showing {(currentPage - 1) * 8 + 1}-
-                  {Math.min(currentPage * 8, paginatedData.totalCount)} of{' '}
+                  Showing {(currentPage - 1) * athletesPerPage + 1}-
+                  {Math.min(currentPage * athletesPerPage, paginatedData.totalCount)} of{' '}
                   {paginatedData.totalCount}
                 </p>
 


### PR DESCRIPTION
## Summary

- Import `coachDashboardStateAtom` to access `athletesPerPage` setting
- Replace hardcoded `8` in pagination display with dynamic value from atom
- Fix misleading 'Debounced search handler' comment (search is immediate)

## Changes

**File**: `src/components/dashboard/coach/AthletesGrid.tsx`

1. **Added import**: `coachDashboardStateAtom` from dashboard atoms
2. **Added state access**: `const { athletesPerPage } = useAtomValue(coachDashboardStateAtom)`
3. **Fixed pagination display**: Lines 236-237 now use `athletesPerPage` instead of hardcoded `8`
4. **Fixed misleading comment**: Updated from "Debounced search handler" to "Search handler - updates search term immediately"

## Why This Matters

- **Consistency**: Pagination display now matches actual pagination logic
- **Maintainability**: Single source of truth for page size (`coachDashboardStateAtom`)
- **Code Quality**: Accurate comments prevent confusion for future developers

Fixes ULT-132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>